### PR TITLE
Add `POST /models` 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,10 +32,6 @@ jobs:
       - name: Move to flask folder
         run: |
           cd app
-      - name: Run isort
-        uses: isort/isort-action@master
-        with:
-          configuration: .
       - name: Run yapf
         id: autoyapf
         uses: mritunjaysharma394/autoyapf@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,10 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com' 
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git config pull.rebase true
+          git config pull.rebase false
           git commit -am "Automated format fixes"
           git pull origin ${{ github.head_ref }}
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:${{ github.head_ref }} --force
       - name: Run test suite
         run: |
           pipenv run pytest

--- a/app/dtos/__init__.py
+++ b/app/dtos/__init__.py
@@ -1,2 +1,4 @@
 from .applicant import Applicant
 from .prediction import PredictionResult
+from .model_metadata import ModelMetadata
+from .train import TrainResult

--- a/app/dtos/__init__.py
+++ b/app/dtos/__init__.py
@@ -1,4 +1,4 @@
 from .applicant import Applicant
-from .prediction import PredictionResult
 from .model_metadata import ModelMetadata
+from .prediction import PredictionResult
 from .train import TrainResult

--- a/app/dtos/model_metadata.py
+++ b/app/dtos/model_metadata.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+from flask_restx import fields
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    model_class: fields.String = fields.String(
+        title="Model class",
+        description="The name of the model class",
+        enum=["logistic", "linear"],
+        required=True,
+    )
+    learning_rate: fields.Float = fields.Float(
+        title="Predicted success",
+        description="The success of the given applicant predicted by the model",
+        required=True,
+    )
+    k: fields.Integer = fields.Integer(
+        title="K-fold cross validation",
+        description="Value used in K-fold cross validation",
+        min=1,
+    )

--- a/app/dtos/train.py
+++ b/app/dtos/train.py
@@ -16,11 +16,10 @@ class TrainResult:
         description="Model accuracy tested on training set",
         required=True,
         min=0.0,
-        max=1.0
-    )
+        max=1.0)
     valid_acc: fields.Float = fields.Float(
         title="Validation accuracy",
         description="Model accuracy tested on validation set",
         min=0.0,
         max=1.0,
-    ) 
+    )

--- a/app/dtos/train.py
+++ b/app/dtos/train.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from flask_restx import fields
+
+
+@dataclass(frozen=True)
+class TrainResult:
+    model_id: fields.Integer = fields.Integer(
+        title="Model ID",
+        description="The ID of the created model",
+        required=True,
+        min=1,
+    )
+    train_acc: fields.Float = fields.Float(
+        title="Training accuracy",
+        description="Model accuracy tested on training set",
+        required=True,
+        min=0.0,
+        max=1.0
+    )
+    valid_acc: fields.Float = fields.Float(
+        title="Validation accuracy",
+        description="Model accuracy tested on validation set",
+        min=0.0,
+        max=1.0,
+    ) 

--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -3,13 +3,29 @@ from typing import Any, Dict
 
 from flask_restx import Namespace, Resource
 
-from app.dtos import Applicant, PredictionResult
+from app.dtos import Applicant, PredictionResult, ModelMetadata, TrainResult
 
 api = Namespace(name="models", description="Models API")
 applicant = api.model(name="Applicant", model=asdict(Applicant()))
+model_metadata = api.model(name="ModelMetadata",
+                              model=asdict(ModelMetadata()))
+train_result = api.model(name="TrainResult", model=asdict(TrainResult()))
 prediction_result = api.model(name="PredictionResult",
                               model=asdict(PredictionResult()))
 
+
+@api.route("")
+class ModelList(Resource):
+    def get(self) -> Dict[str, Any]:
+        # TODO (jihyo): Function Comment 
+        return {}
+
+    @api.expect(model_metadata)
+    @api.marshal_with(train_result, code=201)
+    @api.response(400, "Invalid input")
+    def post(self) -> Dict[str, Any]:
+        """Trains a model with the client specified model class and hyperparameters"""
+        return {"model_id": 1, "train_acc": 0.1, "valid_acc": 0.1}
 
 @api.route("/<int:model_id>/predict")
 @api.param("model_id", description="The model ID")
@@ -25,3 +41,5 @@ class ModelPrediction(Resource):
             api.abort(400, "Invalid model ID")
         # TODO (kyungmin): Implement the endpoint
         return {"model_id": model_id, "success": False}
+
+

--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 from flask_restx import Namespace, Resource
 
-from app.dtos import Applicant, PredictionResult, ModelMetadata, TrainResult
+from app.dtos import Applicant, ModelMetadata, PredictionResult, TrainResult
 
 api = Namespace(name="models", description="Models API")
 applicant = api.model(name="Applicant", model=asdict(Applicant()))

--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -7,8 +7,7 @@ from app.dtos import Applicant, ModelMetadata, PredictionResult, TrainResult
 
 api = Namespace(name="models", description="Models API")
 applicant = api.model(name="Applicant", model=asdict(Applicant()))
-model_metadata = api.model(name="ModelMetadata",
-                              model=asdict(ModelMetadata()))
+model_metadata = api.model(name="ModelMetadata", model=asdict(ModelMetadata()))
 train_result = api.model(name="TrainResult", model=asdict(TrainResult()))
 prediction_result = api.model(name="PredictionResult",
                               model=asdict(PredictionResult()))
@@ -16,8 +15,9 @@ prediction_result = api.model(name="PredictionResult",
 
 @api.route("")
 class ModelList(Resource):
+
     def get(self) -> Dict[str, Any]:
-        # TODO (jihyo): Function Comment 
+        # TODO (jihyo): Function Comment
         return {}
 
     @api.expect(model_metadata)
@@ -26,6 +26,7 @@ class ModelList(Resource):
     def post(self) -> Dict[str, Any]:
         """Trains a model with the client specified model class and hyperparameters"""
         return {"model_id": 1, "train_acc": 0.1, "valid_acc": 0.1}
+
 
 @api.route("/<int:model_id>/predict")
 @api.param("model_id", description="The model ID")
@@ -41,5 +42,3 @@ class ModelPrediction(Resource):
             api.abort(400, "Invalid model ID")
         # TODO (kyungmin): Implement the endpoint
         return {"model_id": model_id, "success": False}
-
-


### PR DESCRIPTION
## Purpose

This PR resolves #8 by creating a `POST /models`. This allows the client to specify the type of model class and its hyperparameters to the server side where they can train a specified model and return the model id and the accuracies

## Changes

1. Added two DTOs
- `TrainResult` : result of the trained model such as accuracies
- `ModelMetadata` : model class and its corresponding hyperparameters

2.Created `POST  /model`

## Additional Comments
