### PR TITLE
Add `GET /models/{mode_id}` 

### DIFF
--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -36,13 +36,18 @@ class ModelList(Resource):
         return ModelService.train(
             ModelMetadata(model_class="linear", learning_rate=0.5)), 201
 
-@api.route("/<int:model_id>/")
+@api.route("/<int:model_id>")
 @api.param("model_id", description="The model ID")
 class ModelMetadata(Resource):
     
     @api.marshal_with(model_metadata, code=200)
     @api.response(400, "Invalid input")
+    @api.response(404, "Model does not exist")
     def get(self, model_id: int) -> Tuple[Dict[str, Any], int]:
+        if model_id <= 0:
+            api.abort(400, "Invalid model ID")
+        if not ModelService.get_model(model_id):
+            api.abort(404, "Model does not exist")
         return ModelService.get_model(model_id), 200
 
 @api.route("/<int:model_id>/predict")

--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -38,7 +38,7 @@ class ModelList(Resource):
 
 @api.route("/<int:model_id>")
 @api.param("model_id", description="The model ID")
-class ModelMetadata(Resource):
+class Model(Resource):
     
     @api.marshal_with(model_metadata, code=200)
     @api.response(400, "Invalid input")

--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -36,6 +36,14 @@ class ModelList(Resource):
         return ModelService.train(
             ModelMetadata(model_class="linear", learning_rate=0.5)), 201
 
+@api.route("/<int:model_id>/")
+@api.param("model_id", description="The model ID")
+class ModelMetadata(Resource):
+    
+    @api.marshal_with(model_metadata, code=200)
+    @api.response(400, "Invalid input")
+    def get(self, model_id: int) -> Tuple[Dict[str, Any], int]:
+        return ModelService.get_model(model_id), 200
 
 @api.route("/<int:model_id>/predict")
 @api.param("model_id", description="The model ID")

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -1,4 +1,5 @@
 from typing import Generator
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -109,3 +110,19 @@ class TestModels:
             assert resp.status_code == 200
             assert data["model_id"] == 2
             assert not data["success"]
+
+    def test_get_model_metadata(self, client: FlaskClient) -> None:
+        url = "/api/models/{}"
+
+        # Model ID must be a number
+        resp = client.get(url.format("abcd"))
+        assert resp.status_code == 400
+
+        # Model ID must be positive
+        resp = client.get(url.format(0))
+        assert resp.status_code == 400
+
+        # Returns desired data
+        with patch.object(ModelService, "get_mode", return_value=Optional[ModelMetadata]):
+            resp = client.get(url)
+            assert resp.status_code == 200

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -125,12 +125,12 @@ class TestModels:
 
         # Model must exist
         with patch.object(ModelService, "get_model", return_value=None):
-            resp = client.get(url)
+            resp = client.get(url.format(1))
             assert resp.status_code == 404
 
         # Returns desired data
         with patch.object(ModelService, "get_model", return_value=ModelMetadata(model_class="linear", learning_rate=0.5, k=2)):
-            resp = client.get(url)
+            resp = client.get(url.format(1))
             data = resp.get_json()
             assert resp.status_code == 200
             assert data["model_class"] == "linear"

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -123,6 +123,11 @@ class TestModels:
         resp = client.get(url.format(0))
         assert resp.status_code == 400
 
+        # Model must exist
+        with patch.object(ModelService, "get_model", return_value=None):
+            resp = client.get(url)
+            assert resp.status_code == 404
+
         # Returns desired data
         with patch.object(ModelService, "get_model", return_value=ModelMetadata(model_class="linear", learning_rate=0.5, k=2)):
             resp = client.get(url)

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -116,13 +116,13 @@ class TestModels:
 
         # Model ID must be a number
         resp = client.get(url.format("abcd"))
-        assert resp.status_code == 400
+        assert resp.status_code == 404
 
         # Model ID must be positive
         resp = client.get(url.format(0))
         assert resp.status_code == 400
 
         # Returns desired data
-        with patch.object(ModelService, "get_mode", return_value=Optional[ModelMetadata]):
+        with patch.object(ModelService, "get_model", return_value=Optional[ModelMetadata]):
             resp = client.get(url)
             assert resp.status_code == 200

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -7,6 +7,7 @@ from flask.testing import FlaskClient
 
 from app.app import app
 from app.dtos import TrainResult
+from app.dtos import ModelMetadata
 from app.services import ModelService
 
 
@@ -123,6 +124,10 @@ class TestModels:
         assert resp.status_code == 400
 
         # Returns desired data
-        with patch.object(ModelService, "get_model", return_value=Optional[ModelMetadata]):
+        with patch.object(ModelService, "get_model", return_value=ModelMetadata(model_class="linear", learning_rate=0.5, k=2)):
             resp = client.get(url)
+            data = resp.get_json()
             assert resp.status_code == 200
+            assert data["model_class"] == "linear"
+            assert 0 <= data["learning_rate"] <= 1
+            assert data["k"] == 2


### PR DESCRIPTION
## Purpose

This PR resolves #19 and #20 by creating a GET /models/{model_id} and adding unit tests for this function. This allows the client to specify a model ID and get the corresponding model metadata in return.

## Changes

1. Created GET /models/{model_id} in app/handlers/models.py
2. Added unit tests in app/tests/test_models.py

## Additional Comments
