### PR TITLE
Add and test `DELETE /models/{model_id}`

### DIFF
--- a/app/handlers/models.py
+++ b/app/handlers/models.py
@@ -50,6 +50,17 @@ class Model(Resource):
             api.abort(404, "Model does not exist")
         return ModelService.get_model(model_id), 200
 
+    @api.response(400, "Invalid input")
+    @api.response(404, "Model does not exist")
+    def delete(self, model_id: int) -> '':
+        '''Delete a model given its id'''
+        if model_id <= 0:
+            api.abort(400, "Invalid model ID")
+        if not ModelService.get_model(model_id):
+            api.abort(404, "Model does not exist")
+        ModelService.delete(model_id)
+        return '', 204
+
 @api.route("/<int:model_id>/predict")
 @api.param("model_id", description="The model ID")
 class ModelPrediction(Resource):

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -18,3 +18,8 @@ class ModelService:
     def predict(model_id: int, applicant: Applicant) -> bool:
         # TODO (kyungmin): Implement this function
         return False
+
+    @staticmethod
+    def delete(model_id: int) -> None:
+        # TODO (victor): Implement this function
+        return None

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -136,3 +136,24 @@ class TestModels:
             assert data["model_class"] == "linear"
             assert 0 <= data["learning_rate"] <= 1
             assert data["k"] == 2
+
+    def test_delete_model(self, client: FlaskClient) -> None:
+        url = "/api/models/{}"
+ 
+        # Model ID must be an integer
+        resp = client.delete(url.format('testinginput'))
+        assert resp.status_code == 404
+ 
+        # Model ID must be positive
+        resp = client.delete(url.format(0))
+        assert resp.status_code == 400
+ 
+        # Model must exist to be deleted
+        with patch.object(ModelService, "get_model", return_value=None):
+            resp = client.delete(url.format(1))
+            assert resp.status_code == 404
+ 
+        # Deleting should return 204
+        with patch.object(ModelService, "get_model", return_value=ModelMetadata(model_class="logistic", learning_rate=0.5)):
+            resp = client.delete(url.format(1))
+            assert resp.status_code == 204


### PR DESCRIPTION
## Purpose

This pr resolves issues #10 and #14 by documenting the API delete endpoint and adding tests for deleting a model.

## Changes

Changed files:

Added `DELETE/models/:id` to the API to delete a singular model.

- test_models.py (added testing for delete endpoint to make sure id inputs are valid and that the response code is 204 when successful)
- models.py (added flask-restx decorators to document the endpoint)
- model_service.py

## Additional Comments
When running the environment and going to /api/docs, this is the result:
![image](https://user-images.githubusercontent.com/98916181/199347655-629cc663-093c-43d8-a2a9-a1d1c520842e.png)

