### PR TITLE
Implement get_model()

### DIFF
--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -1,3 +1,4 @@
+import pickle
 import uuid
 from dataclasses import asdict
 from pathlib import Path
@@ -6,7 +7,6 @@ from typing import List, Optional, Tuple
 
 import joblib
 import pandas as pd
-import pickle
 from sklearn.base import RegressorMixin
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import accuracy_score, r2_score
@@ -28,9 +28,10 @@ class ModelService:
     @staticmethod
     def get_model(model_id: str) -> Optional[ModelMetadata]:
         try:
-            f = open(model_id + ".txt", "r")
+            f = open(f"{model_id}.txt", "r")
         except FileNotFoundError:
             return None
+
         data = f.readlines()
         f.close()
         return ModelMetadata(

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple
 
 import joblib
 import pandas as pd
+import pickle
 from sklearn.base import RegressorMixin
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import accuracy_score, r2_score
@@ -26,14 +27,19 @@ data_dir = Path().cwd().parent.joinpath("data")
 class ModelService:
     @staticmethod
     def get_model(model_id: str) -> Optional[ModelMetadata]:
+        try:
+            f = open(model_id + ".txt", "r")
+        except FileNotFoundError:
+            return
+        data = f.readlines()
         return ModelMetadata(
             model_id=model_id,
-            model_class="logistic",
-            score_func="f_classif",
-            num_features=10,
-            k=2,
-            train_acc=0.5,
-            valid_acc=0.5,
+            model_class=data[0].split(":")[1],
+            score_func=data[1].split(":")[1],
+            num_features=int(data[2].split(":")[1]),
+            k=int(data[3].split(":")[1]),
+            train_acc=float(data[4].split(":")[1]),
+            valid_acc=float(data[5].split(":")[1]),
         )
 
     @staticmethod

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -30,8 +30,9 @@ class ModelService:
         try:
             f = open(model_id + ".txt", "r")
         except FileNotFoundError:
-            return
+            return None
         data = f.readlines()
+        f.close()
         return ModelMetadata(
             model_id=model_id,
             model_class=data[0].split(":")[1],


### PR DESCRIPTION
## Purpose

This PR resolves #34 by implementing the get_model() function in app/services/model_service.py which handles GET requests for /models/{model_id}. This PR is related to #22 which created the API docs for GET /models/{model_id}

## Changes

In app/services/model_service.py, implemented the get_model() function to take in the model ID, open and parse the data in the corresponding {model_id}.txt file, and return a ModelMetadata object with the parsed data.

## Additional Comments
